### PR TITLE
feat: initial impl of the selection dialog

### DIFF
--- a/src/StrictDocOslcRmServer/StrictDocOslcRm/Controllers/ServiceProviderController.cs
+++ b/src/StrictDocOslcRmServer/StrictDocOslcRm/Controllers/ServiceProviderController.cs
@@ -155,17 +155,7 @@ public class ServiceProviderController(
                 (r.Title ?? string.Empty).ToLowerInvariant().Contains(termLower) ||
                 (r.Identifier ?? string.Empty).ToLowerInvariant().Contains(termLower));
         }
-
-        // Content negotiation: if Accept JSON explicitly or query asks for json, return OSLC selection results JSON
-        var accept = request?.Headers["Accept"].ToString();
-        if ((accept != null &&
-             accept.Contains("application/json", StringComparison.OrdinalIgnoreCase))
-            && !string.Equals(accept, "text/html", StringComparison.OrdinalIgnoreCase))
-        {
-            var json = BuildSelectionResultsJson(filtered);
-            return Content(json, "application/json", Encoding.UTF8);
-        }
-
+        
         var isHtmx = request?.Headers.ContainsKey("HX-Request") == true || request?.Headers.ContainsKey("hx-request") == true;
 
         var model = new RequirementSelectionViewModel
@@ -182,32 +172,4 @@ public class ServiceProviderController(
 
         return View("RequirementSelector", model);
     }
-
-    private static string BuildSelectionResultsJson(IEnumerable<Requirement> requirements)
-    {
-        var sb = new StringBuilder();
-        sb.Append("{\n\"oslc:results\": [");
-        var first = true;
-        foreach (var r in requirements)
-        {
-            if (r.GetAbout() == null) continue;
-            if (!first) sb.Append(',');
-            first = false;
-            // Minimal JSON properties per OSLC Delegated Selection Dialog spec
-            sb.Append("{\"oslc:label\":\"")
-                .Append(EscapeJson(r.Title ?? r.Identifier ?? "Requirement"))
-                .Append("\",\"rdf:resource\":\"")
-                .Append(EscapeJson(r.GetAbout()!.ToString()))
-                .Append("\"}");
-        }
-
-        sb.Append("]\n}");
-        return sb.ToString();
-    }
-
-    private static string EscapeJson(string value) => value
-        .Replace("\\", "\\\\")
-        .Replace("\"", "\\\"")
-        .Replace("\r", "\\r")
-        .Replace("\n", "\\n");
 }

--- a/src/StrictDocOslcRmServer/StrictDocOslcRm/Controllers/ServiceProviderController.cs
+++ b/src/StrictDocOslcRmServer/StrictDocOslcRm/Controllers/ServiceProviderController.cs
@@ -148,7 +148,7 @@ public class ServiceProviderController(
                 (r.Title ?? string.Empty).ToLowerInvariant().Contains(termLower) ||
                 (r.Identifier ?? string.Empty).ToLowerInvariant().Contains(termLower));
         }
-        
+
         var isHtmx = request?.Headers.ContainsKey("HX-Request") == true || request?.Headers.ContainsKey("hx-request") == true;
 
         var model = new RequirementSelectionViewModel

--- a/src/StrictDocOslcRmServer/StrictDocOslcRm/Controllers/ServiceProviderController.cs
+++ b/src/StrictDocOslcRmServer/StrictDocOslcRm/Controllers/ServiceProviderController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using OSLC4Net.Core.Model;
 using OSLC4Net.Domains.RequirementsManagement;
+using StrictDocOslcRm.Models;
 using StrictDocOslcRm.Services;
 
 namespace StrictDocOslcRm.Controllers;

--- a/src/StrictDocOslcRmServer/StrictDocOslcRm/Controllers/ServiceProviderController.cs
+++ b/src/StrictDocOslcRmServer/StrictDocOslcRm/Controllers/ServiceProviderController.cs
@@ -1,21 +1,27 @@
-
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using StrictDocOslcRm.Services;
 using System.Globalization;
 using OSLC4Net.Core.Model;
 using OSLC4Net.Domains.RequirementsManagement;
+using System.Text;
+using System.Net;
+using StrictDocOslcRm.Models;
+
+// ReSharper disable StringLiteralTypo
 
 namespace StrictDocOslcRm.Controllers;
+
 /// <summary>
 /// OSLC Service Provider for StrictDoc documents providing Requirements Management capabilities.
 /// </summary>
 [ApiController]
 [Route("/oslc/service_provider")]
 [Produces("application/rdf+xml", "text/turtle", "application/ld+json")]
-public class ServiceProviderController(ILogger<ServiceProviderController> logger,
+public class ServiceProviderController(
+    ILogger<ServiceProviderController> logger,
     IHttpContextAccessor httpContextAccessor,
-    IStrictDocService strictDocService) : ControllerBase
+    IStrictDocService strictDocService) : Controller
 {
     [HttpGet]
     [Route("{documentMid}")]
@@ -23,7 +29,7 @@ public class ServiceProviderController(ILogger<ServiceProviderController> logger
     {
         var documents = await strictDocService.GetDocumentsAsync();
         var document = documents.FirstOrDefault(d => d.Mid == documentMid);
-        
+
         if (document == null)
         {
             return NotFound($"Document with MID '{documentMid}' not found.");
@@ -33,7 +39,8 @@ public class ServiceProviderController(ILogger<ServiceProviderController> logger
         serviceProvider.SetAbout(new Uri(Request.GetEncodedUrl()));
         serviceProvider.SetIdentifier(document.Mid);
         serviceProvider.SetTitle(document.Title);
-        serviceProvider.SetDescription($"OSLC Requirements Management service for StrictDoc document: {document.Title}");
+        serviceProvider.SetDescription(
+            $"OSLC Requirements Management service for StrictDoc document: {document.Title}");
 
         var svc = new OSLC4Net.Core.Model.Service();
         svc.SetDomain(new Uri("http://open-services.net/ns/rm#"));
@@ -42,13 +49,27 @@ public class ServiceProviderController(ILogger<ServiceProviderController> logger
         queryCap.SetTitle("StrictDoc Requirements Query Capability");
         queryCap.SetLabel("StrictDoc Requirements Query Capability");
         queryCap.SetResourceTypes([new Uri("http://open-services.net/ns/rm#Requirement")]);
-        queryCap.SetResourceShape(new Uri("http://open-services.net/ns/rm/shapes/3.0#RequirementShape"));
+        queryCap.SetResourceShape(
+            new Uri("http://open-services.net/ns/rm/shapes/3.0#RequirementShape"));
 
         var request = httpContextAccessor.HttpContext?.Request;
         var baseUrl = $"{request?.Scheme}://{request?.Host}{request?.PathBase}";
-        queryCap.SetQueryBase(new Uri($"{baseUrl}/oslc/service_provider/{documentMid}/requirements"));
+        queryCap.SetQueryBase(
+            new Uri($"{baseUrl}/oslc/service_provider/{documentMid}/requirements"));
 
         svc.AddQueryCapability(queryCap);
+
+        // Selection dialog (delegated UI)
+        var selectionDialog = new Dialog();
+        selectionDialog.SetTitle("Requirement Selection Dialog");
+        selectionDialog.SetLabel("Select Requirement");
+        selectionDialog.SetDialog(
+            new Uri($"{baseUrl}/oslc/service_provider/{documentMid}/requirements/selector"));
+        selectionDialog.SetHintWidth("500px");
+        selectionDialog.SetHintHeight("500px");
+        selectionDialog.SetResourceTypes([new Uri("http://open-services.net/ns/rm#Requirement")]);
+        svc.SetSelectionDialogs([selectionDialog]);
+
         serviceProvider.SetServices([svc]);
 
         return serviceProvider;
@@ -60,9 +81,10 @@ public class ServiceProviderController(ILogger<ServiceProviderController> logger
     {
         var request = httpContextAccessor.HttpContext?.Request;
         var baseUrl = $"{request?.Scheme}://{request?.Host}{request?.PathBase}";
-        
-        var requirements = await strictDocService.GetRequirementsForDocumentAsync(documentMid, baseUrl);
-        
+
+        var requirements =
+            await strictDocService.GetRequirementsForDocumentAsync(documentMid, baseUrl);
+
         if (!requirements.Any())
         {
             return NotFound($"No requirements found for document '{documentMid}'.");
@@ -82,10 +104,11 @@ public class ServiceProviderController(ILogger<ServiceProviderController> logger
 
     [HttpGet]
     [Route("{documentMid}/requirements/{requirementUid}")]
-    public async Task<ActionResult<Requirement>> GetRequirement(string documentMid, string requirementUid)
+    public async Task<ActionResult<Requirement>> GetRequirement(string documentMid,
+        string requirementUid)
     {
         var requirement = await strictDocService.GetRequirementByUidAsync(requirementUid);
-        
+
         if (requirement == null)
         {
             return NotFound($"No requirement found with UID '{requirementUid}'.");
@@ -98,4 +121,93 @@ public class ServiceProviderController(ILogger<ServiceProviderController> logger
 
         return Ok(requirement);
     }
+
+    /// <summary>
+    /// OSLC Delegated Selection Dialog for Requirements.
+    /// Returns HTML (full page or HTMX fragment) or JSON (oslc:results) depending on headers.
+    /// </summary>
+    [HttpGet]
+    [Route("{documentMid}/requirements/selector")]
+    [Produces("text/html", "application/json")]
+    public async Task<IActionResult> RequirementSelector(string documentMid,
+        [FromQuery] string? terms = null)
+    {
+        var request = httpContextAccessor.HttpContext?.Request;
+        var baseUrl = $"{request?.Scheme}://{request?.Host}{request?.PathBase}";
+        var selectorUri = $"{baseUrl}/oslc/service_provider/{documentMid}/requirements/selector";
+
+        // Load all requirements (reuse same sourcing logic as GetRequirements)
+        var requirements =
+            await strictDocService.GetRequirementsForDocumentAsync(documentMid, baseUrl);
+        foreach (var r in requirements)
+        {
+            if (!string.IsNullOrEmpty(r.Identifier))
+            {
+                r.SetAbout(new Uri($"{baseUrl}/?a={r.Identifier}"));
+            }
+        }
+
+        IEnumerable<Requirement> filtered = requirements;
+        if (!string.IsNullOrWhiteSpace(terms))
+        {
+            var termLower = terms.Trim().ToLowerInvariant();
+            filtered = requirements.Where(r =>
+                (r.Title ?? string.Empty).ToLowerInvariant().Contains(termLower) ||
+                (r.Identifier ?? string.Empty).ToLowerInvariant().Contains(termLower));
+        }
+
+        // Content negotiation: if Accept JSON explicitly or query asks for json, return OSLC selection results JSON
+        var accept = request?.Headers["Accept"].ToString();
+        if ((accept != null &&
+             accept.Contains("application/json", StringComparison.OrdinalIgnoreCase))
+            && !string.Equals(accept, "text/html", StringComparison.OrdinalIgnoreCase))
+        {
+            var json = BuildSelectionResultsJson(filtered);
+            return Content(json, "application/json", Encoding.UTF8);
+        }
+
+        var isHtmx = request?.Headers.ContainsKey("HX-Request") == true || request?.Headers.ContainsKey("hx-request") == true;
+
+        var model = new RequirementSelectionViewModel
+        {
+            SelectorUri = selectorUri,
+            Terms = terms,
+            Results = filtered
+        };
+
+        if (isHtmx)
+        {
+            return PartialView("_RequirementSelectorResults", model);
+        }
+
+        return View("RequirementSelector", model);
+    }
+
+    private static string BuildSelectionResultsJson(IEnumerable<Requirement> requirements)
+    {
+        var sb = new StringBuilder();
+        sb.Append("{\n\"oslc:results\": [");
+        var first = true;
+        foreach (var r in requirements)
+        {
+            if (r.GetAbout() == null) continue;
+            if (!first) sb.Append(',');
+            first = false;
+            // Minimal JSON properties per OSLC Delegated Selection Dialog spec
+            sb.Append("{\"oslc:label\":\"")
+                .Append(EscapeJson(r.Title ?? r.Identifier ?? "Requirement"))
+                .Append("\",\"rdf:resource\":\"")
+                .Append(EscapeJson(r.GetAbout()!.ToString()))
+                .Append("\"}");
+        }
+
+        sb.Append("]\n}");
+        return sb.ToString();
+    }
+
+    private static string EscapeJson(string value) => value
+        .Replace("\\", "\\\\")
+        .Replace("\"", "\\\"")
+        .Replace("\r", "\\r")
+        .Replace("\n", "\\n");
 }

--- a/src/StrictDocOslcRmServer/StrictDocOslcRm/Models/RequirementSelectionViewModel.cs
+++ b/src/StrictDocOslcRmServer/StrictDocOslcRm/Models/RequirementSelectionViewModel.cs
@@ -1,0 +1,10 @@
+namespace StrictDocOslcRm.Models;
+
+using OSLC4Net.Domains.RequirementsManagement;
+
+public class RequirementSelectionViewModel
+{
+    public string SelectorUri { get; set; } = string.Empty;
+    public string? Terms { get; set; }
+    public IEnumerable<Requirement> Results { get; set; } = Enumerable.Empty<Requirement>();
+}

--- a/src/StrictDocOslcRmServer/StrictDocOslcRm/Program.cs
+++ b/src/StrictDocOslcRmServer/StrictDocOslcRm/Program.cs
@@ -5,8 +5,8 @@ using OSLC4Net.Server.Providers;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Add services to the container
-builder.Services.AddControllers(o => o.OutputFormatters.Insert(0, new OslcRdfOutputFormatter()));
+// Add services to the container (controllers + views for Razor selection dialog)
+builder.Services.AddControllersWithViews(o => o.OutputFormatters.Insert(0, new OslcRdfOutputFormatter()));
 
 // Configure CORS to allow requests from any domain
 builder.Services.AddCors(options =>
@@ -54,7 +54,7 @@ app.UseStaticFiles();
 
 app.UseRouting();
 
-// Map API controllers only
+// Map controllers (attribute routes) and enable view endpoints
 app.MapControllers();
 
 app.Run();

--- a/src/StrictDocOslcRmServer/StrictDocOslcRm/Views/ServiceProvider/RequirementSelector.cshtml
+++ b/src/StrictDocOslcRmServer/StrictDocOslcRm/Views/ServiceProvider/RequirementSelector.cshtml
@@ -14,17 +14,10 @@
 </head>
 <body>
     <main class="container-fluid">
-        @* <hgroup> *@
-        @*     <h1>Select Requirement</h1> *@
-        @*     <p>Find a specific OSLC resource through a free-text search.</p> *@
-        @* </hgroup> *@
         <input type="search" id="searchTerms" name="terms" value="@Html.Encode(termsValue)" placeholder="Begin typing to search for StrictDoc requirements" autofocus autocomplete="off"
                hx-trigger="input changed delay:160ms, keyup[key=='Enter']" hx-get="@Model.SelectorUri" hx-target="#search-results" hx-ext="aria-busy" />
         <div id="search-results">
-            @if (!string.IsNullOrWhiteSpace(Model.Terms))
-            {
-                @await Html.PartialAsync("_RequirementSelectorResults", Model)
-            }
+            @await Html.PartialAsync("_RequirementSelectorResults", Model)
         </div>
     </main>
     <script>

--- a/src/StrictDocOslcRmServer/StrictDocOslcRm/Views/ServiceProvider/RequirementSelector.cshtml
+++ b/src/StrictDocOslcRmServer/StrictDocOslcRm/Views/ServiceProvider/RequirementSelector.cshtml
@@ -1,0 +1,51 @@
+@model StrictDocOslcRm.Models.RequirementSelectionViewModel
+@{
+    Layout = null; // standalone dialog page
+    var termsValue = Model.Terms ?? string.Empty;
+}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Requirement Selection Dialog</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@@picocss/pico@1/css/pico.min.css" />
+    <script src="https://unpkg.com/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>
+</head>
+<body>
+    <main class="container-fluid">
+        @* <hgroup> *@
+        @*     <h1>Select Requirement</h1> *@
+        @*     <p>Find a specific OSLC resource through a free-text search.</p> *@
+        @* </hgroup> *@
+        <input type="search" id="searchTerms" name="terms" value="@Html.Encode(termsValue)" placeholder="Begin typing to search for StrictDoc requirements" autofocus autocomplete="off"
+               hx-trigger="input changed delay:160ms, keyup[key=='Enter']" hx-get="@Model.SelectorUri" hx-target="#search-results" hx-ext="aria-busy" />
+        <div id="search-results">
+            @if (!string.IsNullOrWhiteSpace(Model.Terms))
+            {
+                @await Html.PartialAsync("_RequirementSelectorResults", Model)
+            }
+        </div>
+    </main>
+    <script>
+        function sendOslcSelectionPostMessage(target, event) {
+            const message = {
+                'oslc:results': [{ 'oslc:label': target.text, 'rdf:resource': target.href }]
+            };
+            window.parent.postMessage('oslc-response:' + JSON.stringify(message), '*');
+            event.preventDefault();
+            return false;
+        }
+        htmx.defineExtension('aria-busy', {
+            onEvent: function (name, evt) {
+                var elt = evt.detail.elt;
+                if (name === 'htmx:beforeRequest') {
+                    elt.setAttribute('aria-busy', 'true');
+                } else if (name === 'htmx:afterRequest') {
+                    elt.removeAttribute('aria-busy');
+                }
+            }
+        });
+    </script>
+</body>
+</html>

--- a/src/StrictDocOslcRmServer/StrictDocOslcRm/Views/ServiceProvider/_RequirementSelectorResults.cshtml
+++ b/src/StrictDocOslcRmServer/StrictDocOslcRm/Views/ServiceProvider/_RequirementSelectorResults.cshtml
@@ -1,0 +1,22 @@
+@model StrictDocOslcRm.Models.RequirementSelectionViewModel
+<div class="grid" style="--block-spacing-vertical: 0.75rem">
+@{
+    var results = Model.Results.Take(50).ToList();
+    if (!results.Any())
+    {
+        <p>No results.</p>
+    }
+    else
+    {
+        foreach (var r in results)
+        {
+            var label = r.Title ?? r.Identifier ?? "Requirement";
+            var href = r.GetAbout()?.ToString();
+            if (href == null) continue;
+            <article>
+                <a href="@href" onclick="return sendOslcSelectionPostMessage(this,event)">@label</a>
+            </article>
+        }
+    }
+}
+</div>

--- a/src/StrictDocOslcRmServer/StrictDocOslcRm/Views/_ViewImports.cshtml
+++ b/src/StrictDocOslcRmServer/StrictDocOslcRm/Views/_ViewImports.cshtml
@@ -1,0 +1,1 @@
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers


### PR DESCRIPTION
Introduces a first implementation of the OSLC Selection Dialog using HTMX and PicoCSS on the client side and some very rudimentary ASP Razor templating on the server side.

When tested via https://oslc.github.io/oslc-selection-utils/ , the dialog looks like this:

<img width="1042" height="749" alt="image" src="https://github.com/user-attachments/assets/48b5b92e-622d-4296-b539-5bc192b02b13" />

Upon selecting on the requirements:

<img width="1349" height="434" alt="image" src="https://github.com/user-attachments/assets/3d8d8c20-5d00-46d0-915f-885a59045c42" />
