### PR TITLE
feat: expose Jazz-compatible RM discovery metadata

### DIFF
--- a/src/StrictDocOslcRmServer/StrictDocOslcRm.Tests/RequirementControllerTests.GetRequirementResource_ReturnsOk.verified.ttl
+++ b/src/StrictDocOslcRmServer/StrictDocOslcRm.Tests/RequirementControllerTests.GetRequirementResource_ReturnsOk.verified.ttl
@@ -2,7 +2,8 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
 
-<http://localhost:8080/?a=REQ-001> <http://purl.org/dc/terms/description> "This is a test requirement"^^rdf:XMLLiteral;
+<http://localhost:8080/?a=REQ-001> <http://open-services.net/ns/core#instanceShape> <http://localhost:8080/oslc/shapes/requirement>;
+                                   <http://purl.org/dc/terms/description> "This is a test requirement"^^rdf:XMLLiteral;
                                    <http://purl.org/dc/terms/identifier> "REQ-001";
                                    <http://purl.org/dc/terms/title> "Test Requirement"^^rdf:XMLLiteral;
                                    a <http://open-services.net/ns/rm#Requirement>.

--- a/src/StrictDocOslcRmServer/StrictDocOslcRm.Tests/RequirementControllerTests.cs
+++ b/src/StrictDocOslcRmServer/StrictDocOslcRm.Tests/RequirementControllerTests.cs
@@ -62,6 +62,11 @@ public class RequirementControllerTests : IAsyncDisposable
 
         // Assert
         var okResult = result as OkObjectResult;
+        var returnedRequirement = okResult?.Value as Requirement;
+        await Assert.That(returnedRequirement?.InstanceShape)
+            .IsEqualTo(new Uri($"{baseUrl}/oslc/shapes/requirement"));
+        await Assert.That(_controller.Response.Headers.Link.ToString())
+            .Contains($"<{baseUrl}/oslc/shapes/requirement>; rel=\"http://open-services.net/ns/core#instanceShape\"");
         await Verify(okResult?.Value).ConfigureAwait(false);
     }
 }

--- a/src/StrictDocOslcRmServer/StrictDocOslcRm.Tests/RequirementShapeControllerTests.cs
+++ b/src/StrictDocOslcRmServer/StrictDocOslcRm.Tests/RequirementShapeControllerTests.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using OSLC4Net.Core.Model;
+using StrictDocOslcRm.Controllers;
+using StrictDocOslcRm.Services;
+
+namespace StrictDocOslcRm.Tests;
+
+public sealed class RequirementShapeControllerTests
+{
+    [Test]
+    public async Task Get_ReturnsProviderOwnedRequirementShape()
+    {
+        var baseUrlService = Substitute.For<IBaseUrlService>();
+        baseUrlService.GetBaseUrl().Returns("https://strictdoc.example.test");
+        var controller = new RequirementShapeController(baseUrlService);
+
+        var result = controller.Get() as OkObjectResult;
+
+        await Assert.That(result?.Value).IsTypeOf<ResourceShape>();
+        var shape = (ResourceShape)result!.Value!;
+        await Assert.That(shape.GetAbout()).IsEqualTo(
+            new Uri("https://strictdoc.example.test/oslc/shapes/requirement"));
+    }
+}

--- a/src/StrictDocOslcRmServer/StrictDocOslcRm.Tests/RootServicesControllerTests.cs
+++ b/src/StrictDocOslcRmServer/StrictDocOslcRm.Tests/RootServicesControllerTests.cs
@@ -1,0 +1,38 @@
+using System.Xml.Linq;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using StrictDocOslcRm.Controllers;
+using StrictDocOslcRm.Services;
+
+namespace StrictDocOslcRm.Tests;
+
+public sealed class RootServicesControllerTests
+{
+    [Test]
+    public async Task RootServices_AdvertisesJazzRmCatalogDescriptor()
+    {
+        var baseUrlService = Substitute.For<IBaseUrlService>();
+        baseUrlService.GetBaseUrl().Returns("https://strictdoc.example.test/");
+        var logger = Substitute.For<ILogger<RootServicesController>>();
+        var configuration = new ConfigurationBuilder().Build();
+        var controller = new RootServicesController(logger, baseUrlService, configuration);
+
+        var result = controller.GetRootServices() as ContentResult;
+
+        await Assert.That(result).IsNotNull();
+        var document = XDocument.Parse(result!.Content!);
+        XNamespace rdf = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
+        XNamespace oslc = "http://open-services.net/ns/core#";
+        XNamespace jazzDiscovery = "http://jazz.net/xmlns/prod/jazz/discovery/1.0/";
+        var catalog = document.Root!
+            .Element(jazzDiscovery + "oslcCatalogs")!
+            .Element(oslc + "ServiceProviderCatalog");
+
+        await Assert.That(catalog?.Attribute(rdf + "about")?.Value)
+            .IsEqualTo("https://strictdoc.example.test/oslc/catalog");
+        await Assert.That(catalog?.Element(oslc + "domain")?.Attribute(rdf + "resource")?.Value)
+            .IsEqualTo("http://open-services.net/ns/rm#");
+    }
+}

--- a/src/StrictDocOslcRmServer/StrictDocOslcRm/Controllers/CatalogController.cs
+++ b/src/StrictDocOslcRmServer/StrictDocOslcRm/Controllers/CatalogController.cs
@@ -1,5 +1,6 @@
-using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
+using OSLC4Net.Core.Model;
+using OSLC4Net.Domains.RequirementsManagement;
 using StrictDocOslcRm.Services;
 
 namespace StrictDocOslcRm.Controllers;
@@ -19,7 +20,12 @@ public class CatalogController(
     public async Task<OSLC4Net.Core.Model.ServiceProviderCatalog> Get()
     {
         var catalog = new OSLC4Net.Core.Model.ServiceProviderCatalog();
-        catalog.SetAbout(new Uri(Request.GetEncodedUrl()));
+        var baseUrl = baseUrlService.GetBaseUrl().TrimEnd('/');
+        catalog.SetAbout(new Uri($"{baseUrl}/oslc/catalog"));
+        catalog.SetTitle("StrictDoc Requirements Management Service Provider Catalog");
+        catalog.SetDescription(
+            "Service provider catalog for the StrictDoc Requirements Management server");
+        catalog.AddDomain(new Uri(RM.NS));
 
         try
         {
@@ -44,9 +50,10 @@ public class CatalogController(
         var serviceProvider = new OSLC4Net.Core.Model.ServiceProvider();
 
         // Set the about URI for this service provider using the document MID
-        var baseUrl = baseUrlService.GetBaseUrl();
+        var baseUrl = baseUrlService.GetBaseUrl().TrimEnd('/');
         var serviceProviderUri = new Uri($"{baseUrl}/oslc/service_provider/{document.Mid}");
         serviceProvider.SetAbout(serviceProviderUri);
+        serviceProvider.SetDetails([serviceProviderUri]);
 
         // Set identifier using the MID
         serviceProvider.SetIdentifier(document.Mid);
@@ -56,6 +63,33 @@ public class CatalogController(
 
         // Set description
         serviceProvider.SetDescription($"OSLC Requirements Management service for StrictDoc document: {document.Title}");
+
+        var service = new Service();
+        service.SetDomain(new Uri(RM.NS));
+
+        var queryCapability = new QueryCapability();
+        queryCapability.SetTitle("StrictDoc Requirements Query Capability");
+        queryCapability.SetLabel("StrictDoc Requirements Query Capability");
+        queryCapability.SetResourceTypes(
+            [new Uri(RM.Requirement)]);
+        queryCapability.SetResourceShape(
+            new Uri($"{baseUrl}/oslc/shapes/requirement"));
+        queryCapability.SetQueryBase(
+            new Uri($"{serviceProviderUri}/requirements"));
+        service.AddQueryCapability(queryCapability);
+
+        var selectionDialog = new Dialog();
+        selectionDialog.SetTitle("Requirement Selection Dialog");
+        selectionDialog.SetLabel("Select Requirement");
+        selectionDialog.SetDialog(
+            new Uri($"{serviceProviderUri}/requirements/selector"));
+        selectionDialog.SetHintWidth("650px");
+        selectionDialog.SetHintHeight("500px");
+        selectionDialog.SetResourceTypes(
+            [new Uri(RM.Requirement)]);
+        service.SetSelectionDialogs([selectionDialog]);
+
+        serviceProvider.SetServices([service]);
 
         return serviceProvider;
     }

--- a/src/StrictDocOslcRmServer/StrictDocOslcRm/Controllers/RequirementController.cs
+++ b/src/StrictDocOslcRmServer/StrictDocOslcRm/Controllers/RequirementController.cs
@@ -33,7 +33,7 @@ public class RequirementController(
             return BadRequest("Parameter 'a' (requirement UID) is required.");
         }
 
-        var baseUrl = baseUrlService.GetBaseUrl();
+        var baseUrl = baseUrlService.GetBaseUrl().TrimEnd('/');
         var allRequirements = await strictDocService.GetAllRequirementsAsync(baseUrl);
         var requirement = allRequirements.FirstOrDefault(r => string.Equals(r.Identifier, a, StringComparison.Ordinal));
 
@@ -152,10 +152,13 @@ public class RequirementController(
 
         // Handle regular Requirement resource request
         requirement.SetAbout(new Uri(requirementUri));
+        requirement.InstanceShape = new Uri($"{baseUrl}/oslc/shapes/requirement");
 
         // Add Link header for Compact resource (OSLC Resource Preview spec)
         Response.Headers.Append("Link",
             $"<{requirementUri}&compact>; rel=\"{OslcConstants.OSLC_CORE_NAMESPACE}Compact\"");
+        Response.Headers.Append("Link",
+            $"<{baseUrl}/oslc/shapes/requirement>; rel=\"{OslcConstants.OSLC_CORE_NAMESPACE}instanceShape\"");
 
         return Ok(requirement);
     }

--- a/src/StrictDocOslcRmServer/StrictDocOslcRm/Controllers/RequirementShapeController.cs
+++ b/src/StrictDocOslcRmServer/StrictDocOslcRm/Controllers/RequirementShapeController.cs
@@ -1,0 +1,27 @@
+using Microsoft.AspNetCore.Mvc;
+using OSLC4Net.Core.Model;
+using OSLC4Net.Domains.RequirementsManagement;
+using StrictDocOslcRm.Services;
+
+namespace StrictDocOslcRm.Controllers;
+
+/// <summary>
+/// Provider-owned OSLC ResourceShape for StrictDoc requirements.
+/// </summary>
+[ApiController]
+[Route("/oslc/shapes/requirement")]
+[Produces("application/rdf+xml", "text/turtle", "application/ld+json", "application/json")]
+public class RequirementShapeController(IBaseUrlService baseUrlService) : ControllerBase
+{
+    [HttpGet]
+    public IActionResult Get()
+    {
+        var shape = ResourceShapeFactory.CreateResourceShape(
+            baseUrlService.GetBaseUrl().TrimEnd('/'),
+            "oslc/shapes",
+            "requirement",
+            typeof(Requirement));
+
+        return Ok(shape);
+    }
+}

--- a/src/StrictDocOslcRmServer/StrictDocOslcRm/Controllers/RootServicesController.cs
+++ b/src/StrictDocOslcRmServer/StrictDocOslcRm/Controllers/RootServicesController.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Text;
 using Microsoft.AspNetCore.Mvc;
+using OSLC4Net.Domains.RequirementsManagement;
 using StrictDocOslcRm.Services;
 
 namespace StrictDocOslcRm.Controllers;
@@ -17,20 +18,27 @@ public class RootServicesController(
     public IActionResult GetRootServices()
     {
         logger.LogDebug("Received request for OSLC Root Services document");
-        var baseUrl = baseUrlService.GetBaseUrl();
+        var baseUrl = baseUrlService.GetBaseUrl().TrimEnd('/');
+        var escapedBaseUrl = WebUtility.HtmlEncode(baseUrl);
         var serviceTitle = WebUtility.HtmlEncode(configuration["OSLC:ServiceTitle"] ?? "OSLC Requirements Management server for StrictDoc");
 
         var rootServicesBody = $$"""
             <?xml version="1.0" encoding="UTF-8"?>
             <rdf:Description
                     xmlns:oslc_rm="http://open-services.net/xmlns/rm/1.0/"
+                    xmlns:oslc="http://open-services.net/ns/core#"
                     xmlns:dc="http://purl.org/dc/terms/"
                     xmlns:jfs="http://jazz.net/xmlns/prod/jazz/jfs/1.0/"
                     xmlns:jd="http://jazz.net/xmlns/prod/jazz/discovery/1.0/"
                     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-                    rdf:about="{{baseUrl}}/.well-known/oslc/rootservices.xml">
+                    rdf:about="{{escapedBaseUrl}}/.well-known/oslc/rootservices.xml">
                 <dc:title>{{serviceTitle}}</dc:title>
-                <oslc_rm:rmServiceProviders rdf:resource="{{baseUrl}}/oslc/catalog" />
+                <oslc_rm:rmServiceProviders rdf:resource="{{escapedBaseUrl}}/oslc/catalog" />
+                <jd:oslcCatalogs>
+                    <oslc:ServiceProviderCatalog rdf:about="{{escapedBaseUrl}}/oslc/catalog">
+                        <oslc:domain rdf:resource="{{RM.NS}}" />
+                    </oslc:ServiceProviderCatalog>
+                </jd:oslcCatalogs>
                 <jd:jsaSsoEnabled>false</jd:jsaSsoEnabled>
             </rdf:Description>
             """;

--- a/src/StrictDocOslcRmServer/StrictDocOslcRm/Controllers/ServiceProviderController.cs
+++ b/src/StrictDocOslcRmServer/StrictDocOslcRm/Controllers/ServiceProviderController.cs
@@ -1,4 +1,3 @@
-using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using OSLC4Net.Core.Model;
 using OSLC4Net.Domains.RequirementsManagement;
@@ -31,24 +30,27 @@ public class ServiceProviderController(
             return NotFound($"Document with MID '{documentMid}' not found.");
         }
 
+        var baseUrl = baseUrlService.GetBaseUrl().TrimEnd('/');
+        var serviceProviderUri =
+            new Uri($"{baseUrl}/oslc/service_provider/{Uri.EscapeDataString(documentMid)}");
         var serviceProvider = new OSLC4Net.Core.Model.ServiceProvider();
-        serviceProvider.SetAbout(new Uri(Request.GetEncodedUrl()));
+        serviceProvider.SetAbout(serviceProviderUri);
+        serviceProvider.SetDetails([serviceProviderUri]);
         serviceProvider.SetIdentifier(document.Mid);
         serviceProvider.SetTitle(document.Title);
         serviceProvider.SetDescription(
             $"OSLC Requirements Management service for StrictDoc document: {document.Title}");
 
         var svc = new OSLC4Net.Core.Model.Service();
-        svc.SetDomain(new Uri("http://open-services.net/ns/rm#"));
+        svc.SetDomain(new Uri(RM.NS));
 
         var queryCap = new QueryCapability();
         queryCap.SetTitle("StrictDoc Requirements Query Capability");
         queryCap.SetLabel("StrictDoc Requirements Query Capability");
-        queryCap.SetResourceTypes([new Uri("http://open-services.net/ns/rm#Requirement")]);
+        queryCap.SetResourceTypes([new Uri(RM.Requirement)]);
         queryCap.SetResourceShape(
-            new Uri("http://open-services.net/ns/rm/shapes/3.0#RequirementShape"));
+            new Uri($"{baseUrl}/oslc/shapes/requirement"));
 
-        var baseUrl = baseUrlService.GetBaseUrl();
         queryCap.SetQueryBase(
             new Uri($"{baseUrl}/oslc/service_provider/{documentMid}/requirements"));
 
@@ -60,9 +62,9 @@ public class ServiceProviderController(
         selectionDialog.SetLabel("Select Requirement");
         selectionDialog.SetDialog(
             new Uri($"{baseUrl}/oslc/service_provider/{documentMid}/requirements/selector"));
-        selectionDialog.SetHintWidth("500px");
+        selectionDialog.SetHintWidth("650px");
         selectionDialog.SetHintHeight("500px");
-        selectionDialog.SetResourceTypes([new Uri("http://open-services.net/ns/rm#Requirement")]);
+        selectionDialog.SetResourceTypes([new Uri(RM.Requirement)]);
         svc.SetSelectionDialogs([selectionDialog]);
 
         serviceProvider.SetServices([svc]);
@@ -80,7 +82,7 @@ public class ServiceProviderController(
     [Route("{documentMid}/requirements")]
     public async Task<IActionResult> GetRequirements(string documentMid)
     {
-        var baseUrl = baseUrlService.GetBaseUrl();
+        var baseUrl = baseUrlService.GetBaseUrl().TrimEnd('/');
 
         var documents = await strictDocService.GetDocumentsAsync();
         if (documents.All(d => !string.Equals(d.Mid, documentMid, StringComparison.Ordinal)))
@@ -96,6 +98,7 @@ public class ServiceProviderController(
             if (!string.IsNullOrEmpty(requirement.Identifier))
             {
                 requirement.SetAbout(new Uri($"{baseUrl}/?a={requirement.Identifier}"));
+                requirement.InstanceShape = new Uri($"{baseUrl}/oslc/shapes/requirement");
             }
         }
 
@@ -168,8 +171,9 @@ public class ServiceProviderController(
         }
 
         // Set the About URI using new format
-        var baseUrl = baseUrlService.GetBaseUrl();
+        var baseUrl = baseUrlService.GetBaseUrl().TrimEnd('/');
         requirement.SetAbout(new Uri($"{baseUrl}/?a={requirementUid}"));
+        requirement.InstanceShape = new Uri($"{baseUrl}/oslc/shapes/requirement");
 
         return Ok(requirement);
     }
@@ -184,7 +188,7 @@ public class ServiceProviderController(
     public async Task<IActionResult> RequirementSelector(string documentMid,
         [FromQuery] string? terms = null)
     {
-        var baseUrl = baseUrlService.GetBaseUrl();
+        var baseUrl = baseUrlService.GetBaseUrl().TrimEnd('/');
         var selectorUri = $"{baseUrl}/oslc/service_provider/{documentMid}/requirements/selector";
 
         // Load all requirements (reuse same sourcing logic as GetRequirements)
@@ -195,6 +199,7 @@ public class ServiceProviderController(
             if (!string.IsNullOrEmpty(r.Identifier))
             {
                 r.SetAbout(new Uri($"{baseUrl}/?a={r.Identifier}"));
+                r.InstanceShape = new Uri($"{baseUrl}/oslc/shapes/requirement");
             }
         }
 


### PR DESCRIPTION
## What changed

- expose a provider-owned requirement ResourceShape and advertise it from requirements and RM query capabilities
- enrich the RM service-provider catalog and Jazz root-services catalog descriptor
- normalize public-base URI composition and use generated RM vocabulary constants

## Why

Jazz discovers writable OSLC affordances from the selected resource and its service-provider metadata. The prior server advertised only the standard external RM shape URI and omitted the Jazz catalog descriptor, preventing reliable provider-owned shape discovery.
